### PR TITLE
Pragma updated, new constructor syntax

### DIFF
--- a/contracts/ExtendedSimpleAuthorization.sol
+++ b/contracts/ExtendedSimpleAuthorization.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 import "./SimpleAuthorization.sol";
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 contract Migrations {
   address public owner;
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/contracts/ReferenceToken.sol
+++ b/contracts/ReferenceToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
@@ -25,7 +25,7 @@ contract ReferenceToken is Ownable, ERC20, ValidatedToken {
     // Single validator
     TokenValidator internal validator;
 
-    function ReferenceToken(
+    constructor(
         string         _name,
         string         _symbol,
         uint256        _granularity,

--- a/contracts/SimpleAuthorization.sol
+++ b/contracts/SimpleAuthorization.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./TokenValidator.sol";
@@ -8,7 +8,7 @@ import "./TokenValidator.sol";
 contract SimpleAuthorization is TokenValidator, Ownable {
     mapping(address => bool) private auths;
 
-    function SimpleAuthorization() public Ownable {}
+    constructor() public {}
 
     function check(
         address /* token */,

--- a/contracts/TokenValidator.sol
+++ b/contracts/TokenValidator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 interface TokenValidator {
   function check(

--- a/contracts/ValidatedToken.sol
+++ b/contracts/ValidatedToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.23;
 
 interface ValidatedToken {
   event Validation(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5545,7 +5545,7 @@
         "jsonfile": "3.0.1",
         "solidity-coverage": "0.4.14",
         "solium": "0.5.5",
-        "truffle": "4.1.6"
+        "truffle": "4.1.7"
       },
       "dependencies": {
         "jsonfile": {
@@ -10543,9 +10543,9 @@
       "integrity": "sha1-Q66MQZ/TrAVqBfip0fsQIs1B7MI="
     },
     "solc": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.22.tgz",
-      "integrity": "sha512-ExrPo2qqCPXo4vXEJaROHExlBdIqgV1vv5fwXMwIc19AUujlQyfyXX8AM7kOQ7xkyHqZ3rj7LJ/BHssAbHym6w==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
+      "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -10563,7 +10563,7 @@
         "async": "2.6.0",
         "glob": "7.1.2",
         "lodash": "4.17.5",
-        "solc": "0.4.22",
+        "solc": "0.4.23",
         "web3": "0.19.1",
         "yargs": "8.0.2"
       },
@@ -11909,13 +11909,13 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.6.tgz",
-      "integrity": "sha512-0b3vZHEM/R6JT3E/K5AB4r/REEwnFqm0YnhUcCoWzjEMRCExcRlATHqePos99Q/KFixJp3+X+zhDkx86WUWnLw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.7.tgz",
+      "integrity": "sha512-fe6BIcD9xo6iIJvV1m6ZhOk56kmB8k38kdoWOKYnPPw7ZUUSupgojeTb2K5e+4qIpIHvEvmET4yLUjSGR+hvwA==",
       "requires": {
         "mocha": "3.5.3",
         "original-require": "1.0.1",
-        "solc": "0.4.21"
+        "solc": "0.4.23"
       },
       "dependencies": {
         "commander": {
@@ -11982,9 +11982,9 @@
           }
         },
         "solc": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.21.tgz",
-          "integrity": "sha512-8lJmimVjOG9AJOQRWS2ph4rSctPMsPGZ4H360HLs5iI+euUlt7iAvUxSLeFZZzwk0kas4Qta7HmlMXNU3yYwhw==",
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
+          "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
           "requires": {
             "fs-extra": "0.30.0",
             "memorystream": "0.3.1",
@@ -12789,7 +12789,7 @@
         "isomorphic-fetch": "2.2.1",
         "request": "2.85.0",
         "semaphore": "1.1.0",
-        "solc": "0.4.22",
+        "solc": "0.4.23",
         "tape": "4.9.0",
         "web3": "0.16.0",
         "xhr": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eip777": "^0.0.3",
     "eip820": "^0.0.17",
     "giveth-common-contracts": "^0.5.0",
-    "solc": "^0.4.22",
+    "solc": "^0.4.23",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "npm-watch": "^0.3.0",
     "solhint": "^1.1.10",
     "solidity-coverage": "^0.4.14",
-    "truffle": "^4.1.6",
+    "truffle": "^4.1.7",
     "zeppelin-solidity": "1.8.0"
   }
 }


### PR DESCRIPTION
There is still one warning 
```
zeppelin-solidity/contracts/ownership/Ownable.sol:20:3: Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
  function Ownable() public {
  ^ (Relevant source part starts here and spans across multiple lines).
```


because OpenZeppelin have not updated their dependency, but I guess it's ok.